### PR TITLE
Change directory for DB dump; exit if script can't enter that directory

### DIFF
--- a/cjp/scripts/dumpArticleTables.sh
+++ b/cjp/scripts/dumpArticleTables.sh
@@ -8,8 +8,12 @@
 # Postgres documentation for details.
 
 DATABASE_URL=chicagojustice.cbeugrz1koxf.us-east-1.rds.amazonaws.com
+OUTPUT_DIRECTORY=/home/sftp_users/files
 
-cd ~
+cd $OUTPUT_DIRECTORY
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
 mkdir cjp_tables
 psql cjpweb_prd -h $DATABASE_URL -U cjpuser -c "\\copy newsarticles_article to 'cjp_tables/newarticles_article.csv' with csv"
 psql cjpweb_prd -h $DATABASE_URL -U cjpuser -c "\\copy newsarticles_category to 'cjp_tables/newsarticles_category.csv' with csv"


### PR DESCRIPTION
Database dump script now writes to a directory accessible to SFTP-only users, and exits if it cannot cd into that directory.